### PR TITLE
Use a version of osg-configure that doesn't bail on fetch-crl error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,13 @@ RUN groupadd -g 64 -r condor
 RUN useradd -r -g condor -d /var/lib/condor -s /sbin/nologin \
     -u 64 -c "Owner of HTCondor Daemons" condor
 
+# FIXME: get the latest osg-configure so that fetch-crl errors don't prevent CE configuration:
+# https://opensciencegrid.atlassian.net/browse/SOFTWARE-4364
 RUN yum install -y --enablerepo=osg-testing \
                    --enablerepo=osg-upcoming-testing \
                    osg-ce-condor \
                    certbot && \
+    yum update -y --enablerepo=osg-development osg-configure && \
     yum clean all && \
     rm -rf /var/cache/yum/
 


### PR DESCRIPTION
Saw this error with the Open Science CE:

```
Running /usr/sbin/fetch-crl, this process may take some time to fetch all the crl updates
fetch-crl script had some errors:
ERROR verify called on empty data blob
ERROR CRL verification failed for ASGCCA-2007/0 (ASGCCA-2007)
VERBOSE(0) ASGCCA-2007/0: 0
VERBOSE(0) ASGCCA-2007/0: downloaded CRL lastUpdate could not be derived
ERROR CRL verification failed for UNLPGrid/0 (UNLPGrid)
VERBOSE(0) UNLPGrid/0: CRL has nextUpdate time in the past

/usr/lib64/python3.6/re.py:212: FutureWarning: split() requires a non-empty pattern match.
  return _compile(pattern, flags).split(string, maxsplit)
ERROR    Error while running fetch-crl script
CRITICAL Can't configure module, exiting
Can't configure module, exiting
You may be able to get more details rerunning /usr/sbin/osg-configure with the -d option and/or by examining /var/log/osg/osg-configure.log
```